### PR TITLE
Fixes Disney Parks not working correctly

### DIFF
--- a/amusement/parks/disney/DisneyPark.py
+++ b/amusement/parks/disney/DisneyPark.py
@@ -47,7 +47,7 @@ class DisneyPark(Park):
             'x-UJinn-Copyright' : 'Copyright UIEvolution Inc.',
             'Proxy-Connection' : 'keep-alive',
             'Accept-Encoding' :'compress, gzip',
-            'Authorization' : self._auth_token,
+            'Authorization' : 'BEARER ' + self._auth_token,
             'X-Conversation-Id' : '~WDPRO-MOBILE.CLIENT-PROD'
         }
 


### PR DESCRIPTION
WDWPro now requires "BEARER" before a wait-time request which renders the current library useless. This change aims to fix that.